### PR TITLE
J cords lps 75080

### DIFF
--- a/portal-workflow-kaleo-runtime-impl/build.gradle
+++ b/portal-workflow-kaleo-runtime-impl/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.rules.engine.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.push.notifications.api", version: "1.2.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "javax.mail", name: "mail", version: "1.4"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/WorkflowGroupServiceSettings.java
+++ b/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/WorkflowGroupServiceSettings.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.internal;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.settings.FallbackKeys;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsFactoryUtil;
+import com.liferay.portal.kernel.settings.TypedSettings;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+/**
+ * @author Iván Zaera
+ * @author Joshua Cords
+ */
+@Settings.Config(settingsIds = WorkflowConstants.SERVICE_NAME)
+public class WorkflowGroupServiceSettings {
+
+	public static WorkflowGroupServiceSettings getInstance(long groupId)
+		throws PortalException {
+
+		Settings settings = SettingsFactoryUtil.getSettings(
+			new GroupServiceSettingsLocator(
+				groupId, WorkflowConstants.SERVICE_NAME));
+
+		return new WorkflowGroupServiceSettings(settings);
+	}
+
+	public WorkflowGroupServiceSettings(Settings settings) {
+		_typedSettings = new TypedSettings(settings);
+	}
+
+	public String getEmailFromAddress() {
+		return _typedSettings.getValue("emailFromAddress");
+	}
+
+	public String getEmailFromName() {
+		return _typedSettings.getValue("emailFromName");
+	}
+
+	private static FallbackKeys _getFallbackKeys() {
+		FallbackKeys fallbackKeys = new FallbackKeys();
+
+		fallbackKeys.add(
+			"emailFromAddress", PropsKeys.WORKFLOW_EMAIL_FROM_ADDRESS,
+			PropsKeys.ADMIN_EMAIL_FROM_ADDRESS);
+		fallbackKeys.add(
+			"emailFromName", PropsKeys.WORKFLOW_EMAIL_FROM_NAME,
+			PropsKeys.ADMIN_EMAIL_FROM_NAME);
+
+		return fallbackKeys;
+	}
+
+	static {
+		SettingsFactoryUtil.registerSettingsMetadata(
+			WorkflowGroupServiceSettings.class, null, _getFallbackKeys());
+	}
+
+	private final TypedSettings _typedSettings;
+
+}

--- a/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/EmailNotificationSender.java
+++ b/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/EmailNotificationSender.java
@@ -16,10 +16,12 @@ package com.liferay.portal.workflow.kaleo.runtime.internal.notification;
 
 import com.liferay.mail.kernel.model.MailMessage;
 import com.liferay.mail.kernel.service.MailService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.kaleo.definition.NotificationReceptionType;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+import com.liferay.portal.workflow.kaleo.runtime.internal.WorkflowGroupServiceSettings;
 import com.liferay.portal.workflow.kaleo.runtime.notification.BaseNotificationSender;
 import com.liferay.portal.workflow.kaleo.runtime.notification.NotificationRecipient;
 import com.liferay.portal.workflow.kaleo.runtime.notification.NotificationSender;
@@ -69,8 +71,18 @@ public class EmailNotificationSender
 		Map<String, Serializable> workflowContext =
 			executionContext.getWorkflowContext();
 
+		long groupId = GetterUtil.getLong(
+			workflowContext.get(WorkflowConstants.CONTEXT_GROUP_ID));
+
+		WorkflowGroupServiceSettings workflowGroupServiceSettings =
+			WorkflowGroupServiceSettings.getInstance(groupId);
+
 		String fromAddress = (String)workflowContext.get(
 			WorkflowConstants.CONTEXT_NOTIFICATION_SENDER_ADDRESS);
+
+		if (Validator.isNull(fromAddress)) {
+			fromAddress = workflowGroupServiceSettings.getEmailFromAddress();
+		}
 
 		if (Validator.isNull(fromAddress)) {
 			fromAddress = _fromAddress;
@@ -78,6 +90,10 @@ public class EmailNotificationSender
 
 		String fromName = (String)workflowContext.get(
 			WorkflowConstants.CONTEXT_NOTIFICATION_SENDER_NAME);
+
+		if (Validator.isNull(fromName)) {
+			fromName = workflowGroupServiceSettings.getEmailFromName();
+		}
 
 		if (Validator.isNull(fromName)) {
 			fromName = _fromName;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-75080
https://issues.liferay.com/browse/LPP-27403

This pull is dependent on changes to master.

I'm adding functionality for configuring the email.from.name and email.from.address for the workflow module. I'm following the pattern found in Blogs and elsewhere where [ServiceSettings](https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/settings/BlogsGroupServiceSettings.java) configures the fallbackKeys which is called by the [BlogsLSI](https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java#L1878-L1879)