### PR TITLE
LPS-75533

### DIFF
--- a/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -38,13 +38,3 @@ renderResponse.setTitle(assetRenderer.getTitle(locale));
 		assetRendererFactory="<%= assetRendererFactory %>"
 	/>
 </c:if>
-
-<%
-String viewInContextURL = assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, null);
-%>
-
-<c:if test="<%= viewInContextURL != null %>">
-	<div class="asset-more">
-		<aui:a href="<%= viewInContextURL %>"><liferay-ui:message key="view-in-context" /> &raquo;</aui:a>
-	</div>
-</c:if>


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-27661
https://issues.liferay.com/browse/LPS-75533

Clicking "View in Context" from "My Workflow Tasks" (when viewing the full content from this portlet) results in errors. We primarily tested with Web Content articles configured to display from specific pages, although it appears to cause errors for other types of asset entries as well (like documents).

In the case of Web Content, this seems to be an intentional limitation of the Asset Publisher. Clicking the "View in Context" link from this location appears to try to load the pending version of the content, but the code in `view_content.jsp` appears to be specifically set up to prevent it from doing so. The link redirects by passing in only information for the "urlTitle" for the asset entry, which then causes it to go through [this code using an `AssetRendererFactory` in `view_content.jsp`](https://github.com/Alec-Shay/liferay-portal/blob/master/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp#L41); however, this cannot be used to retrieve pending versions of Web Content. Theoretically, the urlTitle could be used to retrieve it using different API (i.e., `JournalArticleLocalServiceUtil`), but there does not appear to be a good way to determine whether to load pending content, since the code goes through the same route as if normally viewing content in the Asset Publisher, and it does not appear to be possible to pass more helpful distinguishing information from portal-workflow-task-web's `view_content.jsp` to asset-publisher-web's `view_content.jsp` ([see here for where the link is generated](https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp#L48)).

Additionally, even if the correct asset entries were retrieved in spite of these roadblocks, [this line here](https://github.com/Alec-Shay/liferay-portal/blob/master/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp#L53) seems to be pretty specifically targeted toward preventing the Asset Publisher from displaying these types of entries (pending versions of content are never "visible"). Thus, it seems to us like an intentional limitation of Asset Publisher that it cannot display pending versions of content.

Other types of asset entries (again, like documents) may also show the "View in Context" link -- but we were not able to identify a scenario in which these links actually worked from viewing the documents in "My Workflow Tasks." Thus, it seems like the link as a whole cannot do what it was apparently meant for.

Our proposed solution, thus, is to simply remove the link, because it seems like these components are not designed to allow for viewing pending content in context, and there does not appear to be a simple way to fix this. However, if we have overlooked something, or there is an alternative suggestion, please let me know. Thanks.